### PR TITLE
Add constraints to shifts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 # Devise is a flexible authentication solution for Rails
 gem "devise", "~> 4.7"
 gem 'jquery-rails'
+gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/mimemagicrb/mimemagic.git
+  revision: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  ref: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  specs:
+    mimemagic (0.3.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -111,9 +118,6 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.10)
-      nokogiri (~> 1)
-      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
@@ -243,6 +247,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   jquery-rails
   listen (~> 3.2)
+  mimemagic!
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -8,8 +8,8 @@ class Shift < ApplicationRecord
   validate :end_date_after_start_date?
 
   def end_date_after_start_date?
-    if shift_end < shift_start
-      errors.add :shift_end, "shift must end after shift start"
+    if shift_end < shift_start + 3600
+      errors.add :shift_end, "shift must end at least an hour after shift start"
     end
   end
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -3,7 +3,7 @@ class Shift < ApplicationRecord
   validates :shift_start, :presence => true
   validates :shift_end , :presence => true
   validates :shift_pay, :presence => true
-  validates_numericality_of :shift_pay, greater_than_or_equal_to: 0.00
+  validates_numericality_of :shift_pay, greater_than: 0.00
   
   validate :end_date_after_start_date?
 

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -8,7 +8,7 @@ class Shift < ApplicationRecord
 
    def end_date_after_start_date?
        if shift_end < shift_start
-          errors.add :shift_end, "shift must be after start date"
+          errors.add :shift_end, "shift must be after shift start"
        end
     end
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -15,8 +15,10 @@ class Shift < ApplicationRecord
   end
 
   def shift_start_before_current_date?
-    if shift_start < Time.zone.now
+    if shift_start < Time.zone.now - 100
       errors.add :shift_start, "shift cannot start in the past" 
+    elsif shift_start < Time.zone.now + 3600
+      errors.add :shift_start, "shift must be created at least an hour before start" 
     end
   end
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -1,14 +1,15 @@
 class Shift < ApplicationRecord
-    validates :role_name, :presence => true
-    validates :shift_start, :presence => true
-    validates :shift_end , :presence => true
-    validates :shift_pay, :presence => true
+  validates :role_name, :presence => true
+  validates :shift_start, :presence => true
+  validates :shift_end , :presence => true
+  validates :shift_pay, :presence => true
+  validates_numericality_of :shift_pay, greater_than_or_equal_to: 0.00
   
-   validate :end_date_after_start_date?
+  validate :end_date_after_start_date?
 
-   def end_date_after_start_date?
-       if shift_end < shift_start
-          errors.add :shift_end, "shift must be after shift start"
-       end
+  def end_date_after_start_date?
+    if shift_end < shift_start
+      errors.add :shift_end, "shift must end after shift start"
     end
+  end
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -6,10 +6,17 @@ class Shift < ApplicationRecord
   validates_numericality_of :shift_pay, greater_than: 0.00
   
   validate :end_date_after_start_date?
+  validate :shift_start_before_current_date?
 
   def end_date_after_start_date?
     if shift_end < shift_start + 3600
       errors.add :shift_end, "shift must end at least an hour after shift start"
+    end
+  end
+
+  def shift_start_before_current_date?
+    if shift_start < Time.zone.now
+      errors.add :shift_start, "shift cannot start in the past" 
     end
   end
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -1,2 +1,14 @@
 class Shift < ApplicationRecord
+    validates :role_name, :presence => true
+    validates :shift_start, :presence => true
+    validates :shift_end , :presence => true
+    validates :shift_pay, :presence => true
+  
+   validate :end_date_after_start_date?
+
+   def end_date_after_start_date?
+       if shift_end < shift_start
+          errors.add :shift_end, "shift must be after start date"
+       end
+    end
 end

--- a/db/migrate/20210401032324_add_constraints_to_shifts.rb
+++ b/db/migrate/20210401032324_add_constraints_to_shifts.rb
@@ -1,0 +1,8 @@
+class AddConstraintsToShifts < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :shifts, :role_name, false
+    change_column_null :shifts, :shift_pay, false
+    change_column_null :shifts, :shift_start, false
+    change_column_null :shifts, :shift_end , false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_26_163716) do
+ActiveRecord::Schema.define(version: 2021_04_01_032324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "shifts", force: :cascade do |t|
     t.boolean "shift_status"
-    t.string "role_name"
-    t.datetime "shift_start"
-    t.datetime "shift_end"
-    t.integer "shift_pay"
+    t.string "role_name", null: false
+    t.datetime "shift_start", null: false
+    t.datetime "shift_end", null: false
+    t.integer "shift_pay", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "description"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Feature
- [ ] Refactor
- [ ] Bug Fix
- [ x] Optimization
- [ ] Documentation Update


## Description of what PR does
Closes issue #37 
Adds validations on the Shifts model. An error will popup on the form if conditions are not met. All shifts must now have a role name, pay rate, start and end times. End times must happen after start times. 


## Related PRs (if any)
-
-


## QA Instructions, Screenshots, Recordings
Pull into your local env
Run 
```
bundle install
rails db:migrate
rails s
```
In browser, navigate to http://127.0.0.1:3000/shifts/


## Added tests?

- [ ] yes
- [ x ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help


## Added to documentation?

- [ ] Yes, project README
- [ ] No documentation needed


## [optional] What gif best describes this PR or how it makes you feel?

![Alt-Text](GIF URL)