### PR TITLE
adding if exists to drop devise tables migration

### DIFF
--- a/db/migrate/20210323163228_drop_devise_tables.rb
+++ b/db/migrate/20210323163228_drop_devise_tables.rb
@@ -1,5 +1,5 @@
 class DropDeviseTables < ActiveRecord::Migration[6.0]
   def change
-    drop_table :models
+    drop_table :models, if_exists: true
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Feature
- [ ] Refactor
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update


## Description of what PR does

When I first added devise and created the user model, I incorrectly called it "Models", so it created a table called models in the database. When I changed it to the name "Users" I had to add a migration to drop the models table erroneously created, and when resetting the database I was having a problem with it because the models table didn't exist anymore (as I dropped it). 
I don't know if it would be a problem to any of you, but just in case I'm modifying it and telling to only drop the table if it exists (I would say it is a good practice anyway to add those kind of checkings)


## Related PRs (if any)
-
-


## QA Instructions, Screenshots, Recordings
I would say to just try to db:reset and db:migrate and check it works correctly


## Added tests?

- [ ] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help


## Added to documentation?

- [ ] Yes, project README
- [ ] No documentation needed


## [optional] What gif best describes this PR or how it makes you feel?

![Alt-Text](GIF URL)